### PR TITLE
Revert "Update stefanzweifel/git-auto-commit-action action to v6"

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -123,14 +123,14 @@ jobs:
 
 
       - name: Push new Spotless Apply if available
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           file_pattern: '**/*.kt **/*.kts **/*.xml'
           disable_globbing: true
           commit_message: "🤖 Apply Spotless formatting"
 
       - name: Push new Dependency Guard baselines if available
-        uses: stefanzweifel/git-auto-commit-action@v6
+        uses: stefanzweifel/git-auto-commit-action@v5
         if: steps.dependencyguard_baseline.outcome == 'success'
         with:
           file_pattern: '**/dependencies/*.txt'

--- a/app/dependencies/androidDebugCompileClasspath.txt
+++ b/app/dependencies/androidDebugCompileClasspath.txt
@@ -102,7 +102,7 @@ org.jetbrains.compose.ui:ui-text:1.9.0-beta01
 org.jetbrains.compose.ui:ui-unit:1.9.0-beta01
 org.jetbrains.compose.ui:ui-util:1.9.0-beta01
 org.jetbrains.compose.ui:ui:1.9.0-beta01
-org.jetbrains.kotlin:kotlin-stdlib:2.2.0
+org.jetbrains.kotlin:kotlin-stdlib:2.2.10
 org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.4.0
 org.jetbrains.kotlinx:kotlinx-collections-immutable:0.4.0
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1


### PR DESCRIPTION
Reverts mshdabiola/Kltemplate#15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reverted CI auto-commit steps to a prior stable action version for formatting and dependency baseline updates.
  * Updated Kotlin standard library dependency to 2.2.10 in build files.
  * No user-facing feature, UI, or behavior changes; no action required from users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->